### PR TITLE
Add GitHub Skills activity to course offerings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Overview
This PR adds the missing **GitHub Skills** activity that was announced by the principal but wasn't available for student registration.

## Changes Made
- Added "GitHub Skills" to the activities dictionary in `app.py`
- Activity details:
  - **Description**: Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications
  - **Schedule**: Mondays and Thursdays, 3:30 PM - 5:00 PM
  - **Max Participants**: 25 students
  - **Current Participants**: Empty (ready for registrations)

## Why This Is Important
- ⏰ **Time-sensitive**: Registration deadline is end of this week
- 🎓 **College applications**: Part of GitHub Certifications program
- 👥 **Student demand**: Many students are eager to join after the principal's announcement

Fixes #6